### PR TITLE
fix: float conversion warning in intervention image package

### DIFF
--- a/src/Thumbhash.php
+++ b/src/Thumbhash.php
@@ -87,8 +87,8 @@ class Thumbhash
         $originalHeight = $data->height();
         if ($originalWidth > $this->imageMaxSize || $originalHeight > $this->imageMaxSize) {
             $scale = $this->imageMaxSize / max($originalWidth, $originalHeight);
-            $newWidth = $originalWidth * $scale;
-            $newHeight = $originalHeight * $scale;
+            $newWidth = (int) ($originalWidth * $scale);
+            $newHeight = (int) ($originalHeight * $scale);
             $data = $data->scaleDown($newWidth, $newHeight)->encode()->toString();
         } elseif ($input instanceof File) {
             $data = $input->getContent();


### PR DESCRIPTION
We are getting the following warning in our production log:
![CleanShot 2025-06-04 at 00 02 26](https://github.com/user-attachments/assets/e2066acf-2b03-4a34-b0b0-a0d0cc573230)

After debugging a bit, I found that this package is calling the `scaleDown` method from the `intervention/image` package which is expecting int values as a parameter:
![CleanShot 2025-06-04 at 00 07 16](https://github.com/user-attachments/assets/8bee1f67-f77a-4513-a9c5-9a9f11e5919a)

So, this PR is updating the code to call the method using int values which might fix the issue. 